### PR TITLE
clean up environment files from /tmp directory when switching user sessions

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -21,7 +21,9 @@ class IrodsStorage(Storage):
             self.environment = GLOBAL_ENVIRONMENT
             icommands.ACTIVE_SESSION = self.session
 
-    def set_user_session(self, username=None, password=None, host=settings.IRODS_HOST, port=settings.IRODS_PORT, def_res=None, zone=settings.IRODS_ZONE, userid=0):
+    def set_user_session(self, username=None, password=None, host=settings.IRODS_HOST,
+                         port=settings.IRODS_PORT, def_res=None, zone=settings.IRODS_ZONE,
+                         userid=0, sess_id=None):
         homedir = "/"+zone+"/home/"+username
         userEnv = IRodsEnv(
                pk=userid,
@@ -34,8 +36,16 @@ class IrodsStorage(Storage):
                zone=zone,
                auth=password
             )
-        self.session = Session(session_id=uuid4())
-        self.environment = self.session.create_environment(myEnv=userEnv)
+        if sess_id is None:
+            self.session = Session(session_id=uuid4())
+            self.environment = self.session.create_environment(myEnv=userEnv)
+        else:
+            self.session = Session(session_id=sess_id)
+            if self.session.session_file_exists():
+                self.environment = userEnv
+            else:
+                self.environment = self.session.create_environment(myEnv=userEnv)
+
         self.session.run('iinit', None, self.environment.auth)
         icommands.ACTIVE_SESSION = self.session
 
@@ -47,7 +57,14 @@ class IrodsStorage(Storage):
                                   host=settings.HS_WWW_IRODS_HOST,
                                   port=settings.IRODS_PORT,
                                   def_res=settings.HS_IRODS_LOCAL_ZONE_DEF_RES,
-                                  zone=settings.HS_WWW_IRODS_ZONE)
+                                  zone=settings.HS_WWW_IRODS_ZONE,
+                                  sess_id='federated_session')
+
+
+    def delete_user_session(self):
+        if self.session != GLOBAL_SESSION and self.session.session_file_exists():
+            self.session.delete_environment()
+
 
     def download(self, name):
         return self._open(name, mode='rb')

--- a/storage.py
+++ b/storage.py
@@ -24,7 +24,7 @@ class IrodsStorage(Storage):
     def set_user_session(self, username=None, password=None, host=settings.IRODS_HOST,
                          port=settings.IRODS_PORT, def_res=None, zone=settings.IRODS_ZONE,
                          userid=0, sess_id=None):
-        homedir = "/"+zone+"/home/"+username
+        homedir = "/" + zone + "/home/" + username
         userEnv = IRodsEnv(
                pk=userid,
                host=host,
@@ -35,7 +35,7 @@ class IrodsStorage(Storage):
                username=username,
                zone=zone,
                auth=password
-            )
+        )
         if sess_id is None:
             self.session = Session(session_id=uuid4())
             self.environment = self.session.create_environment(myEnv=userEnv)


### PR DESCRIPTION
@mjstealey @pkdash This PR is for cleaning up irods_environment files from /tmp directory when switching user sessions. Have tested all relevant use cases including irods federation zone-related irods operations and irods operations to retrieve files from non-federated zones. Once this is merged, I will create another PR for HydroShare repo to use the new ```delete_user_session()``` function to make sure irods_environment is cleaned up without left overs. The only two environment files remaining in temp directory after HydroShare container is up are the default_session and federated_session which will not be cleaned up since they will be used throughout HydroShare. Please review the code and see if you can give +1.