### PR TITLE
Prohibit file overwrite in iRODS

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -6,6 +6,7 @@ from django.utils.deconstruct import deconstructible
 from django.conf import settings
 from django.core.files.storage import Storage
 from django.core.urlresolvers import reverse
+from django.core.exceptions import ValidationError
 
 from django_irods import icommands
 from icommands import Session, GLOBAL_SESSION, GLOBAL_ENVIRONMENT, SessionException, IRodsEnv
@@ -259,8 +260,10 @@ class IrodsStorage(Storage):
     def url(self, name):
         return reverse('django_irods.views.download', kwargs={'path': name})
 
-    def get_available_name(self, name): 
+    def get_available_name(self, name):
         """
-        Allow irods to replace existing files 
+        Reject duplicate file names rather than renaming them.
         """
+        if self.exists(name):
+            raise ValidationError(str.format("File {} already exists.", name))
         return name

--- a/storage.py
+++ b/storage.py
@@ -258,3 +258,9 @@ class IrodsStorage(Storage):
 
     def url(self, name):
         return reverse('django_irods.views.download', kwargs={'path': name})
+
+    def get_available_name(self, name): 
+        """
+        Allow irods to replace existing files 
+        """
+        return name


### PR DESCRIPTION
@hyi @pkdash This simple PR allows Django to overwrite existing files, thus preserving its ability to name files the way people request. 
