### PR TITLE
fix unicode in file name issue #2299

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -232,6 +232,7 @@ class IrodsStorage(Storage):
 
     def exists(self, name):
         try:
+            name = u'{file_name}'.format(file_name=name)
             stdout = self.session.run("ils", None, name)[0]
             return stdout != ""
         except SessionException:


### PR DESCRIPTION
@aphelionz This is a further fix to issue #2299. I have applied the fix on dev and tested various file-involved workflow including creating resource with problematic file (i.e., file name including a unicode character), deleting the problematic file from the resource, adding the file into the resource, deleting the whole resource, and everything works after applying this further simple fix. I will ask @horsburgh or @Maurier to test on dev just to be sure, but please code review and see if you can +1 this. I will have to create another PR for HydroShare just to update the SHA reference to point to the new SHA for django_irods submodule after this PR is merged into master.