### PR TITLE
finally got to the bottom of unicode in file name issue

### DIFF
--- a/icommands.py
+++ b/icommands.py
@@ -162,7 +162,8 @@ class Session(object):
 
         cmdStr = os.path.join(self.icommands_path, icommand)
         argList = [cmdStr]
-        argList.extend(args)
+        uargs = [x.encode('utf-8') for x in args]
+        argList.extend(uargs)
 
         stdin = None
         if data:

--- a/storage.py
+++ b/storage.py
@@ -232,7 +232,6 @@ class IrodsStorage(Storage):
 
     def exists(self, name):
         try:
-            name = u'{file_name}'.format(file_name=name)
             stdout = self.session.run("ils", None, name)[0]
             return stdout != ""
         except SessionException:


### PR DESCRIPTION
@aphelionz Can you code review this PR so that it can be merged to fix the unicode in file name issue? I believe I finally got to the bottom of this issue and made the best fix. Once this is merged, I will merge a PR in hydroshare branch that point to the new SHA reference for this django_irods submodule. I have to make a small fix to hydroshare repo to fix this issue as well. My branch has been deployed to park and I'll ask @horsburgh to test there. This PR is targeted for release 1.13 since only partial fix was in develop currently and I'd like the whole fix to be in so this issue will finally be fixed.