### PR TITLE
2567 download folder zips

### DIFF
--- a/views.py
+++ b/views.py
@@ -111,12 +111,13 @@ def download(request, path, rest_call=False, use_async=True, *args, **kwargs):
             if use_async:
                 task = create_temp_zip.apply_async((res_id, input_path, output_path), countdown=3)
                 delete_zip.apply_async((res_id, random_hash_path), countdown=(20 * 60))  # delete after 20 minutes
+                download_path = request.path.split("zips")[0] + output_path
                 if rest_call:
                     return HttpResponse(json.dumps({'zip_status': 'Not ready',
-                                                    'task_id': task.task_id}),
+                                                    'task_id': task.task_id,
+                                                    'download_path': download_path}),
                                         content_type="application/json")
 
-                download_path = request.path.split("zips")[0] + output_path
                 request.session['task_id'] = task.task_id
                 request.session['download_path'] = download_path
                 return HttpResponseRedirect(res.get_absolute_url())

--- a/views.py
+++ b/views.py
@@ -108,9 +108,9 @@ def download(request, path, rest_call=False, use_async=True, *args, **kwargs):
             random_hash_path = 'zips/{res_id}/{rand_folder}'.format(res_id=res_id, rand_folder=random_hash)
             output_path = '{random_hash_path}{path}.zip'.format(random_hash_path=random_hash_path, path=input_path)
 
-            delete_zip.apply_async((res_id, random_hash_path), countdown=(2 * 60))  # delete after 20 minutes
             if use_async:
                 task = create_temp_zip.apply_async((res_id, input_path, output_path), countdown=3)
+                delete_zip.apply_async((res_id, random_hash_path), countdown=(20 * 60))  # delete after 20 minutes
                 if rest_call:
                     return HttpResponse(json.dumps({'zip_status': 'Not ready',
                                                     'task_id': task.task_id}),
@@ -122,6 +122,7 @@ def download(request, path, rest_call=False, use_async=True, *args, **kwargs):
                 return HttpResponseRedirect(res.get_absolute_url())
 
             ret_status = create_temp_zip(res_id, input_path, output_path)
+            delete_zip.apply_async((res_id, random_hash_path), countdown=(20 * 60))  # delete after 20 minutes
             if not ret_status:
                 content_msg = "Zip cannot be created successfully. Check log for details."
                 response = HttpResponse()

--- a/views.py
+++ b/views.py
@@ -89,13 +89,16 @@ def download(request, path, rest_call=False, use_async=True, *args, **kwargs):
             random_hash = random.getrandbits(32)
 
             daily_date = datetime.datetime.today().strftime('%Y-%m-%d')
-            random_hash_path = 'zips/{daily_date}/{res_id}/{rand_folder}'.format(daily_date=daily_date, res_id=res_id,
-                                                                                 rand_folder=random_hash)
-            output_path = '{random_hash_path}{path}.zip'.format(random_hash_path=random_hash_path, path=input_path)
+            random_hash_path = 'zips/{daily_date}/{res_id}/{rand_folder}'.format(
+                daily_date=daily_date, res_id=res_id,
+                rand_folder=random_hash)
+            output_path = '{random_hash_path}{path}.zip'.format(random_hash_path=random_hash_path,
+                                                                path=input_path)
 
             if use_async:
                 task = create_temp_zip.apply_async((res_id, input_path, output_path), countdown=3)
-                delete_zip.apply_async((res_id, random_hash_path), countdown=(20 * 60))  # delete after 20 minutes
+                delete_zip.apply_async((res_id, random_hash_path),
+                                       countdown=(20 * 60))  # delete after 20 minutes
                 download_path = request.path.split("zips")[0] + output_path
                 if rest_call:
                     return HttpResponse(json.dumps({'zip_status': 'Not ready',
@@ -108,7 +111,8 @@ def download(request, path, rest_call=False, use_async=True, *args, **kwargs):
                 return HttpResponseRedirect(res.get_absolute_url())
 
             ret_status = create_temp_zip(res_id, input_path, output_path)
-            delete_zip.apply_async((res_id, random_hash_path), countdown=(20 * 60))  # delete after 20 minutes
+            delete_zip.apply_async((res_id, random_hash_path),
+                                   countdown=(20 * 60))  # delete after 20 minutes
             if not ret_status:
                 content_msg = "Zip cannot be created successfully. Check log for details."
                 response = HttpResponse()

--- a/views.py
+++ b/views.py
@@ -124,29 +124,28 @@ def download(request, path, rest_call=False, use_async=True, *args, **kwargs):
 
             path = output_path
 
-    metadata_dirty = "false"
-    if is_bag_download:
-        bag_modified = istorage.getAVU(res_root, 'bag_modified')
-        # make sure if bag_modified is not set to true, we still recreate the bag if the
-        # bag file does not exist for some reason to resolve the error to download a nonexistent
-        # bag when bag_modified is false due to the flag being out-of-sync with the real bag status
-        if bag_modified is None or bag_modified.lower() == "false":
-            # check whether the bag file exists
-            bag_file_name = res_id + '.zip'
-            if res_root.startswith(res_id):
-                bag_full_path = os.path.join('bags', bag_file_name)
-            else:
-                bag_full_path = os.path.join(federated_path, 'bags', bag_file_name)
-            # set bag_modified to 'true' if the bag does not exist so that it can be recreated
-            # and the bag_modified AVU will be set correctly as well subsequently
-            if not istorage.exists(bag_full_path):
-                bag_modified = 'true'
-        metadata_dirty = istorage.getAVU(res_root, 'metadata_dirty')
-        # do on-demand bag creation
-        # needs to check whether res_id collection exists before getting/setting AVU on it
-        # to accommodate the case where the very same resource gets deleted by another request
-        # when it is getting downloaded
+    bag_modified = istorage.getAVU(res_root, 'bag_modified')
+    # make sure if bag_modified is not set to true, we still recreate the bag if the
+    # bag file does not exist for some reason to resolve the error to download a nonexistent
+    # bag when bag_modified is false due to the flag being out-of-sync with the real bag status
+    if bag_modified is None or bag_modified.lower() == "false":
+        # check whether the bag file exists
+        bag_file_name = res_id + '.zip'
+        if res_root.startswith(res_id):
+            bag_full_path = os.path.join('bags', bag_file_name)
+        else:
+            bag_full_path = os.path.join(federated_path, 'bags', bag_file_name)
+        # set bag_modified to 'true' if the bag does not exist so that it can be recreated
+        # and the bag_modified AVU will be set correctly as well subsequently
+        if not istorage.exists(bag_full_path):
+            bag_modified = 'true'
+    metadata_dirty = istorage.getAVU(res_root, 'metadata_dirty')
+    # do on-demand bag creation
+    # needs to check whether res_id collection exists before getting/setting AVU on it
+    # to accommodate the case where the very same resource gets deleted by another request
+    # when it is getting downloaded
 
+    if is_bag_download:
         # send signal for pre_check_bag_flag
         pre_check_bag_flag.send(sender=resource_cls, resource=res)
         if bag_modified is None or bag_modified.lower() == "true":

--- a/views.py
+++ b/views.py
@@ -97,7 +97,7 @@ def download(request, path, rest_call=False, use_async=True, *args, **kwargs):
 
             if use_async:
                 task = create_temp_zip.apply_async((res_id, input_path, output_path), countdown=3)
-                delete_zip.apply_async((random_hash_path),
+                delete_zip.apply_async((random_hash_path, ),
                                        countdown=(20 * 60))  # delete after 20 minutes
                 download_path = request.path.split("zips")[0] + output_path
                 if rest_call:
@@ -111,7 +111,7 @@ def download(request, path, rest_call=False, use_async=True, *args, **kwargs):
                 return HttpResponseRedirect(res.get_absolute_url())
 
             ret_status = create_temp_zip(res_id, input_path, output_path)
-            delete_zip.apply_async((random_hash_path),
+            delete_zip.apply_async((random_hash_path, ),
                                    countdown=(20 * 60))  # delete after 20 minutes
             if not ret_status:
                 content_msg = "Zip cannot be created successfully. Check log for details."

--- a/views.py
+++ b/views.py
@@ -97,7 +97,7 @@ def download(request, path, rest_call=False, use_async=True, *args, **kwargs):
 
             if use_async:
                 task = create_temp_zip.apply_async((res_id, input_path, output_path), countdown=3)
-                delete_zip.apply_async((res_id, random_hash_path),
+                delete_zip.apply_async((random_hash_path),
                                        countdown=(20 * 60))  # delete after 20 minutes
                 download_path = request.path.split("zips")[0] + output_path
                 if rest_call:
@@ -111,7 +111,7 @@ def download(request, path, rest_call=False, use_async=True, *args, **kwargs):
                 return HttpResponseRedirect(res.get_absolute_url())
 
             ret_status = create_temp_zip(res_id, input_path, output_path)
-            delete_zip.apply_async((res_id, random_hash_path),
+            delete_zip.apply_async((random_hash_path),
                                    countdown=(20 * 60))  # delete after 20 minutes
             if not ret_status:
                 content_msg = "Zip cannot be created successfully. Check log for details."


### PR DESCRIPTION
add folder downloading as zip.  A user can now right click on a folder and choose Download, which makes a request that hits this function.  Zipped folders are placed temporarily on zips/{res_id}/{rand_folder}.  The zipped folder is then scheduled to be deleted after 20 minutes.  Should this time be adjusted or put into settings to be configurable?